### PR TITLE
Improve visualization in narrow screen devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>Socket.IO chat</title>
     <style>
       body { margin: 0; padding-bottom: 3rem; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }


### PR DESCRIPTION
Use the viewport meta tag to improve client visualization on narrow screen devices (i.e. mobile browsers).