### PR TITLE
Bind http server to localhost

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const app = require('express')();
 const http = require('http').Server(app);
 const io = require('socket.io')(http);
+const host = process.env.HOST || 'localhost';
 const port = process.env.PORT || 3000;
 
 app.get('/', (req, res) => {
@@ -13,6 +14,6 @@ io.on('connection', (socket) => {
   });
 });
 
-http.listen(port, () => {
-  console.log(`Socket.IO server running at http://localhost:${port}/`);
+http.listen(port, host, () => {
+  console.log(`Socket.IO server running at http://${host}:${port}/`);
 });


### PR DESCRIPTION
By default, for security reasons, the http server should be binded to localhost.
This default binding can be overriden with the `HOST` environment variable.